### PR TITLE
update gem version in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This gem creates a [Lando](https://lando.dev/) config file for running [Solr](ht
 ## Installation
 1. Add this gem to the `Gemfile` of your Blacklight application:
    ```
-   gem "blacklight_lando", "~> 0.2.0"
+   gem "blacklight_lando", "~> 0.3.0"
    ```
 2. Run `bundle install`
 3. Run `rails generate blacklight_lando:run_solr`


### PR DESCRIPTION
Makes the installation instructions self-consistent.  "blacklight_lando:run_solr" doesn't exist before version 0.3.